### PR TITLE
Inverted cover position to match home assistant's definition

### DIFF
--- a/custom_components/comelit/cover.py
+++ b/custom_components/comelit/cover.py
@@ -40,11 +40,11 @@ class ComelitCover(ComelitDevice, CoverEntity):
 
     @property
     def current_cover_position(self):  # -> int | None:
-        return self._position
+        return 100 - self._position
     
     def set_cover_position(self, position, **kwargs):
         _LOGGER.debug(f"Trying to SET POSITION {position} cover {self.name}! _state={self._state}")
-        self._hub.cover_position(self._id, position)
+        self._hub.cover_position(self._id, 100 - position)
 
     def open_cover(self, stopping=False, **kwargs):
         _LOGGER.debug(f"Trying to OPEN cover {self.name}! _state={self._state}")


### PR DESCRIPTION
Courtesy of the newest UI updates, I have learned that 0% cover means closed, and 100% means open.