### PR TITLE
Update all async_schedule_update_ha_state calls to their non-async counterpart

### DIFF
--- a/custom_components/comelit/climate.py
+++ b/custom_components/comelit/climate.py
@@ -74,11 +74,11 @@ class ComelitClimate(ComelitDevice, ClimateEntity):
         if temperature is not None:
             self._hub.climate_set_temperature(self._id, temperature)
             self._state['target_temperature'] = temperature
-            self.async_schedule_update_ha_state()
+            self.schedule_update_ha_state()
 
     def set_hvac_mode(self, hvac_mode):
         self._hub.climate_set_state(self._id, hvac_mode == HVACMode.HEAT)
-        self.async_schedule_update_ha_state()
+        self.schedule_update_ha_state()
         
     def update(self):
         pass

--- a/custom_components/comelit/comelit_device.py
+++ b/custom_components/comelit/comelit_device.py
@@ -38,7 +38,7 @@ class ComelitDevice(Entity):
         old = self._state
         self._state = state
         if old != state:
-            self.async_schedule_update_ha_state()
+            self.schedule_update_ha_state()
 
     @property
     def state(self):

--- a/custom_components/comelit/cover.py
+++ b/custom_components/comelit/cover.py
@@ -40,11 +40,11 @@ class ComelitCover(ComelitDevice, CoverEntity):
 
     @property
     def current_cover_position(self):  # -> int | None:
-        return self._position
+        return 100 - self._position
     
     def set_cover_position(self, position, **kwargs):
         _LOGGER.debug(f"Trying to SET POSITION {position} cover {self.name}! _state={self._state}")
-        self._hub.cover_position(self._id, position)
+        self._hub.cover_position(self._id, 100 - position)
 
     def open_cover(self, stopping=False, **kwargs):
         _LOGGER.debug(f"Trying to OPEN cover {self.name}! _state={self._state}")

--- a/custom_components/comelit/cover.py
+++ b/custom_components/comelit/cover.py
@@ -56,14 +56,14 @@ class ComelitCover(ComelitDevice, CoverEntity):
         self._hub.cover_up(self._id)
         if not stopping:
             self._state == STATE_OPENING
-        self.async_schedule_update_ha_state()
+        self.schedule_update_ha_state()
 
     def close_cover(self, stopping=False, **kwargs):
         _LOGGER.debug(f"Trying to CLOSE cover {self.name}! _state={self._state}")
         self._hub.cover_down(self._id)
         if not stopping:
             self._state = STATE_CLOSING
-        self.async_schedule_update_ha_state()
+        self.schedule_update_ha_state()
     
     def update_state(self, state, position):
         super().update_state(state)
@@ -72,7 +72,7 @@ class ComelitCover(ComelitDevice, CoverEntity):
             old = self._position
             self._position = position
             if old != position:
-                self.async_schedule_update_ha_state()
+                self.schedule_update_ha_state()
 
     def stop_cover(self, **kwargs):
         _LOGGER.debug(f"Trying to STOP cover {self.name}! is_opening={self.is_opening}, is_closing={self.is_closing}")


### PR DESCRIPTION
This fixes the integration in Home Assistant 2024.5.  Without it, these kinds of errors are thrown, and state is not correctly communicated to HA. https://community.home-assistant.io/t/how-to-fix-custom-integration-brematic-calls-async-write-ha-state/722238/3