### PR TITLE
Enable vedo sensors

### DIFF
--- a/.devcontainer/configuration.yaml
+++ b/.devcontainer/configuration.yaml
@@ -1,6 +1,9 @@
 # Loads default set of integrations. Do not remove.
 default_config:
-
+debugpy:
+  start: true
+#  wait: true #Wait until debugger is attached to start execution
+  
 logger:
   default: info
   logs:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       default: { }
     ports:
       - "8123:8123"
+      - "5678:5678"
     volumes:
       - ../custom_components/comelit:/config/custom_components/comelit
       - ./configuration.yaml:/config/configuration.yaml

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ comelit:
 #### Comelit app
 
 - Open the Comelit app
-- Scan for a new hub device
-- Copy the serial (remove all non-numeric characters, i.e. 'hsrv-0123456789' -> '0123456789' )
+- Scan for a new hub device (Or if it's already added to the app, check in 'Manage Devices' -> Comelit Hub -> Network Configuration -> ID)
+- Copy the serial (Hub MAC Address) (remove all symbols and hsrv prefix, i.e. "HSRV 00:25:29:17:2D:C2" -> "002529172DC2")
 
 For more information, see the [Wiki](https://github.com/gicamm/homeassistant-comelit/wiki).
 

--- a/custom_components/comelit/__init__.py
+++ b/custom_components/comelit/__init__.py
@@ -75,7 +75,7 @@ def setup(hass, config):
             scan_interval = schema[CONF_SCAN_INTERVAL]
             vedo = ComelitVedo(vedo_host, vedo_port, vedo_pwd, scan_interval)
             hass.data[DOMAIN]['vedo'] = vedo
-            # hass.helpers.discovery.load_platform('binary_sensor', DOMAIN, {}, config)
+            hass.helpers.discovery.load_platform('binary_sensor', DOMAIN, {}, config)
             hass.helpers.discovery.load_platform('alarm_control_panel', DOMAIN, {}, config)
             _LOGGER.info("Comelit Vedo integration started")
 

--- a/custom_components/comelit/vedo.py
+++ b/custom_components/comelit/vedo.py
@@ -151,7 +151,7 @@ class ComelitVedo:
         try:
             id = s["id"]
             name = s["name"]
-            if s["status"] == "0011":
+            if s["status"] == "0001":
                 state = STATE_ON
             else:
                 state = STATE_OFF
@@ -240,14 +240,14 @@ class SensorUpdater (Thread):
                     if value == 'Not logged':
                         raise Exception("cookie expired")
 
-                    if value > 1:
+                    if value == 1:
                         sensor_dict = {"index": i, "id": i, "name": description[i], "status": zone_statuses[i]}
                         _LOGGER.debug(f"Updating the zone {sensor_dict}")
                         sensors.append(sensor_dict)
 
                 if self._uid is not None:
-                    # for sensor in sensors:
-                    #     self._vedo.update_sensor(sensor)
+                    for sensor in sensors:
+                        self._vedo.update_sensor(sensor)
 
                     p1_pres = areas_desc["p1_pres"]
                     p2_pres = areas_desc["p2_pres"]


### PR DESCRIPTION
Hi!, I've just integrated this plugin with my HomeAssitant connected to my new Comelit home system. I haven't played a lot yet with all the options, but with a couple changes I was able to see all VEDO sensors in my HASS system.

Result:

<img width="452" alt="Captura de pantalla 2024-05-31 a las 13 21 40" src="https://github.com/gicamm/homeassistant-comelit/assets/2429905/da20d4f3-b8f3-47c9-89ed-ed52a10e570e">

This works with my system, when opening the door, or enabling the motion sensors, the status changes in Home Assistant. Although it's true that a smaller refresh time its needed to properly detect motion. 

I've changed also a couple things that I've find useful for testing:
- Enable debugpy in the HASS yml configuration, this will run home assistant with the python remote debugger enabled. It can be later connected, for example from Visual Studio, to debug the python execution and place breakpoints.
- Updated README, it was confusing the "remove all non-numeric characters", as the serial is a hexadecimal mac address with non numeric characters.

Let me know if more testing is needed or there are scenarios not covered here, or why did the check was `if value > 1` and the status `0011`. 

Thanks