### PR TITLE
Correct dimmer lights not be interpreted as  an ON/OFF light

### DIFF
--- a/custom_components/comelit/light.py
+++ b/custom_components/comelit/light.py
@@ -32,11 +32,11 @@ class ComelitLight(ComelitDevice, LightEntity):
 
     @property
     def supported_color_modes(self):
-        return ColorMode.BRIGHTNESS if self._brightness else {ColorMode.ONOFF}
+        return {ColorMode.BRIGHTNESS} if self._brightness else {ColorMode.ONOFF}
 
     @property
     def color_mode(self):
-        return ColorMode.BRIGHTNESS if self._brightness else ColorMode.ONOFF
+        return {ColorMode.BRIGHTNESS} if self._brightness else {ColorMode.ONOFF}
     
     @property
     def brightness(self):


### PR DESCRIPTION
As described in https://github.com/gicamm/homeassistant-comelit/issues/86
my dimmers were interpreted as ON/OFF lights due to the fact that the variable passed is a value instead of a set. This makes supported_color_modes incorrect.