### PR TITLE
Update vedo binary sensors logic

### DIFF
--- a/.devcontainer/configuration.yaml
+++ b/.devcontainer/configuration.yaml
@@ -1,6 +1,9 @@
 # Loads default set of integrations. Do not remove.
 default_config:
-
+debugpy:
+  start: true
+#  wait: true #Wait until debugger is attached to start execution
+  
 logger:
   default: info
   logs:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       default: { }
     ports:
       - "8123:8123"
+      - "5678:5678"
     volumes:
       - ../custom_components/comelit:/config/custom_components/comelit
       - ./configuration.yaml:/config/configuration.yaml

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ comelit:
 #### Comelit app
 
 - Open the Comelit app
-- Scan for a new hub device
-- Copy the serial (remove all non-numeric characters, i.e. 'hsrv-0123456789' -> '0123456789' )
+- Scan for a new hub device (Or if it's already added to the app, check in 'Manage Devices' -> Comelit Hub -> Network Configuration -> ID)
+- Copy the serial (Hub MAC Address) (remove all symbols and hsrv prefix, i.e. "HSRV 00:25:29:17:2D:C2" -> "002529172DC2")
 
 For more information, see the [Wiki](https://github.com/gicamm/homeassistant-comelit/wiki).
 


### PR DESCRIPTION
The previous PR https://github.com/gicamm/homeassistant-comelit/pull/81 was not totally correct as it was not covering all cases, the same as the current code, which does not work with all vedo installations.

To properly handle sensors, this PR uses the same logic to detect an "OPEN" sensor as the VEDO web panel.

In the VEDO panel the status is not a handled as a string or a number, the string is parsed as a hexadecimal integer and then a bitwise comparison is made to determine the status:

```
var zone_status = parseInt(vedo_zone_data.status[zone_num], 16);
if ($('#zone_list_' + zone_num)) {
	$('#zone_list_' + zone_num + ' .zone_status.state').removeClass('ok fault sabotage alarm');
	if ((zone_status & 2) != 0) {
		$('#zone_list_' + zone_num + ' .zone_status.state').addClass('alarm');
	} else if ((zone_status & 8) != 0) {
		$('#zone_list_' + zone_num + ' .zone_status.state').addClass('sabotage');
	} else if ((zone_status & 4) != 0) {
		$('#zone_list_' + zone_num + ' .zone_status.state').addClass('fault');
	} else if ((zone_status & 1) == 0) {
		$('#zone_list_' + zone_num + ' .zone_status.state').addClass('ok');
	}

	$('#zone_list_' + zone_num + ' .zone_status.open').css('visibility', 'hidden');
	if ((zone_status & 1) != 0) {
		$('#zone_list_' + zone_num + ' .zone_status.open').css('visibility', '');
	}

	$('#zone_list_' + zone_num + ' .zone_status.presence').removeClass('isolated excluded inhibited');
	if ((zone_status & 128) != 0) {
		$('#zone_list_' + zone_num + ' .zone_status.presence').addClass('excluded');
	} else if ((zone_status & 256) != 0) {
		$('#zone_list_' + zone_num + ' .zone_status.presence').addClass('isolated');
	} else if ((zone_status & 32768) != 0) {
		$('#zone_list_' + zone_num + ' .zone_status.presence').addClass('inhibited');
	}
}
```

As in this plugin, these sensors are used as binary sensors, we only case if it's open or not (and not if it's in alarm, sabotage, fault...):

in python:

```
zone_status = int(s["status"], 16)
if (zone_status & 1) != 0:
```

the same with the check to find enabled sensors, in JS the:
```
if (vedo_zone_data.present[zone_num] != '0') {
   // Sensor added to the web panel
}
```

I've changed also a couple things that I've find useful:

- Encoding of the response is now in utf8 to support installations using characters with tildes like `á`
- Enable debugpy in the HASS yml configuration, this will run home assistant with the python remote debugger enabled. It can be later connected, for example from Visual Studio, to debug the python execution and place breakpoints.
- Updated README, it was confusing the "remove all non-numeric characters", as the serial is a hexadecimal mac address with non numeric characters.

I've been testing this code with my installation for the past months without any issue.