### PR TITLE
feat(light): add RGB color mode support

### DIFF
--- a/custom_components/comelit/hub.py
+++ b/custom_components/comelit/hub.py
@@ -1,30 +1,36 @@
 """Platform for sensor integration."""
-import time
-import json
 
-import paho.mqtt.client as mqtt
+import json
+import logging
+import time
 from threading import Thread
 
-from homeassistant.const import STATE_CLOSED, STATE_OPEN, STATE_CLOSING, STATE_OPENING, STATE_ON, STATE_OFF, \
-    STATE_UNKNOWN
-
+import paho.mqtt.client as mqtt
 from homeassistant.components.climate import HVACMode
+from homeassistant.const import (
+    STATE_CLOSED,
+    STATE_CLOSING,
+    STATE_OFF,
+    STATE_ON,
+    STATE_OPEN,
+    STATE_OPENING,
+    STATE_UNKNOWN,
+)
 
-from .scene import ComelitScenario
-from .sensor import PowerSensor, TemperatureSensor, HumiditySensor
-from .light import ComelitLight
-from .cover import ComelitCover
-from .switch import ComelitSwitch
 from .climate import ComelitClimate
-import logging
+from .cover import ComelitCover
+from .light import ComelitLight
+from .scene import ComelitScenario
+from .sensor import HumiditySensor, PowerSensor, TemperatureSensor
+from .switch import ComelitSwitch
 
 _LOGGER = logging.getLogger(__name__)
 
 COMELIT_HUB_COMPONENTS = [
-    'climate',
-    'light',
-    'sensor',
-    'switch',
+    "climate",
+    "light",
+    "sensor",
+    "switch",
 ]
 
 
@@ -41,36 +47,36 @@ class RequestType:
 
 
 class HubFields:
-    TOKEN = 'sessiontoken'
-    TEMPERATURE = 'temperatura'
-    TARGET_TEMPERATURE = 'soglia_attiva'
-    HUMIDITY = 'umidita'
-    DESCRIPTION = 'descrizione'
-    INSTANT_POWER = 'instant_power'
-    ID = 'id'
-    PRODUCTION = 'prod'
-    ELEMENTS = 'elements'
-    COVER_STATUS = 'open_status'
-    STATUS = 'status'
-    DATA = 'data'
-    PARAMETER_NAME = 'param_name'
-    PARAMETER_VALUE = 'param_value'
-    SUB_TYPE = 'sub_type'
-    WINTER_SEASON = 'est_inv'
+    TOKEN = "sessiontoken"
+    TEMPERATURE = "temperatura"
+    TARGET_TEMPERATURE = "soglia_attiva"
+    HUMIDITY = "umidita"
+    DESCRIPTION = "descrizione"
+    INSTANT_POWER = "instant_power"
+    ID = "id"
+    PRODUCTION = "prod"
+    ELEMENTS = "elements"
+    COVER_STATUS = "open_status"
+    STATUS = "status"
+    DATA = "data"
+    PARAMETER_NAME = "param_name"
+    PARAMETER_VALUE = "param_value"
+    SUB_TYPE = "sub_type"
+    WINTER_SEASON = "est_inv"
 
 
 class HubClasses:
-    LOGICAL = 'GEN#PL'
-    AUTOMATION = 'DOM#AU'
-    LIGHT = 'DOM#LT'
-    FTV = 'DOM#CN'
-    POWER_CONSUMPTION = 'DOM#CN'
-    LOAD = 'DOM#LC'
-    TEMPERATURE = 'DOM#CL'
-    SCENARIO = 'DOM#LD'
-    COVER = 'DOM#BL'
-    SCENARIO = 'GEN#SC'
-    OTHER = 'DOM#LD'
+    LOGICAL = "GEN#PL"
+    AUTOMATION = "DOM#AU"
+    LIGHT = "DOM#LT"
+    FTV = "DOM#CN"
+    POWER_CONSUMPTION = "DOM#CN"
+    LOAD = "DOM#LC"
+    TEMPERATURE = "DOM#CL"
+    SCENARIO = "DOM#LD"
+    COVER = "DOM#BL"
+    SCENARIO = "GEN#SC"
+    OTHER = "DOM#LD"
 
 
 # Publish message to mqtt
@@ -107,35 +113,49 @@ def disconnect_callback(client, userdata, rc):
 
 # Manage lights, switch and covers
 class CommandHub:
-
     def __init__(self, hub):
         self._hub = hub
 
-    def on(self, req_type, id, brightness=None):
+    def on(self, req_type, id, brightness=None, color=None):
         try:
-            if brightness is None:
+            if brightness is None and color is None:
                 act_params = [1]
                 act_type = 0
+            elif color is not None:
+                act_type = 15
+                act_params = [*color, brightness]
             else:
                 if req_type is not RequestType.LIGHT:
-                    _LOGGER.error(f'Requested brightness change for a {req_type}!?')
+                    _LOGGER.error(f"Requested brightness change for a {req_type}!?")
                 act_params = [brightness, -1]
                 act_type = 11
 
-            req = {"req_type": req_type, "req_sub_type": 3, "obj_id": id, "act_type": act_type, "act_params": act_params}
+            req = {
+                "req_type": req_type,
+                "req_sub_type": 3,
+                "obj_id": id,
+                "act_type": act_type,
+                "act_params": act_params,
+            }
             self._hub.publish(req)
         except Exception as e:
             _LOGGER.exception("Error opening %s", e)
 
     def off(self, req_type, id):
         try:
-            req = {"req_type": req_type , "req_sub_type": 3, "obj_id": id, "act_type": 0, "act_params": [0]}
+            req = {
+                "req_type": req_type,
+                "req_sub_type": 3,
+                "obj_id": id,
+                "act_type": 0,
+                "act_params": [0],
+            }
             self._hub.publish(req)
         except Exception as e:
             _LOGGER.exception("Error closing %s", e)
 
-    def light_on(self, id, brightness=None):
-        self.on(RequestType.LIGHT, id, brightness)
+    def light_on(self, id, brightness=None, color=None):
+        self.on(RequestType.LIGHT, id, brightness, color)
 
     def light_off(self, id):
         self.off(RequestType.LIGHT, id)
@@ -151,8 +171,14 @@ class CommandHub:
 
     def cover_position(self, id, position):
         try:
-            _LOGGER.info(f'Setting cover {id} to position {position}')
-            req = {"req_type": RequestType.COVER, "req_sub_type": 3, "obj_id": id, "act_type": 52, "act_params": [int(position*255/100)]}
+            _LOGGER.info(f"Setting cover {id} to position {position}")
+            req = {
+                "req_type": RequestType.COVER,
+                "req_sub_type": 3,
+                "obj_id": id,
+                "act_type": 52,
+                "act_params": [int(position * 255 / 100)],
+            }
             self._hub.publish(req)
         except Exception as e:
             _LOGGER.exception("Error setting position %s", e)
@@ -162,15 +188,21 @@ class CommandHub:
 
     def climate_set_temperature(self, id, temperature):
         try:
-            _LOGGER.info(f'Setting climate {id} to temperature {temperature}')
-            req = {"req_type": RequestType.TEMPERATURE, "req_sub_type": 3, "obj_id": id, "act_type": 2, "act_params": [int(temperature*10)]}
+            _LOGGER.info(f"Setting climate {id} to temperature {temperature}")
+            req = {
+                "req_type": RequestType.TEMPERATURE,
+                "req_sub_type": 3,
+                "obj_id": id,
+                "act_type": 2,
+                "act_params": [int(temperature * 10)],
+            }
             self._hub.publish(req)
         except Exception as e:
             _LOGGER.exception("Error setting temperature %s", e)
 
     def climate_set_state(self, id, state):
         try:
-            _LOGGER.info(f'Setting climate {id} to state {state}')
+            _LOGGER.info(f"Setting climate {id} to state {state}")
             if state == HVACMode.HEAT:
                 act_type = 4
                 act_params = [1]
@@ -181,7 +213,13 @@ class CommandHub:
             else:
                 act_type = 0
                 act_params = [0]
-            req = {"req_type": RequestType.TEMPERATURE, "req_sub_type": 3, "obj_id": id, "act_type": act_type, "act_params": act_params}
+            req = {
+                "req_type": RequestType.TEMPERATURE,
+                "req_sub_type": 3,
+                "obj_id": id,
+                "act_type": act_type,
+                "act_params": act_params,
+            }
             self._hub.publish(req)
         except Exception as e:
             _LOGGER.exception("Error setting climate state %s", e)
@@ -189,22 +227,37 @@ class CommandHub:
 
 # Manage scenario
 class SceneHub:
-
     def __init__(self, hub):
         self._hub = hub
 
     def activate(self, id):
         _LOGGER.info("SCENE %s", id)
         try:
-            req = {"req_type": RequestType.SCENARIO, "req_sub_type": 3, "obj_id": id, "act_type": 1000, "act_params": []}
+            req = {
+                "req_type": RequestType.SCENARIO,
+                "req_sub_type": 3,
+                "obj_id": id,
+                "act_type": 1000,
+                "act_params": [],
+            }
             self._hub.publish(req)
         except Exception as e:
             _LOGGER.exception("Error activating the scenario %s", e)
 
 
 class ComelitHub:
-
-    def __init__(self, client_name, hub_serial, hub_host, mqtt_port, mqtt_user, mqtt_password, hub_user, hub_password, scan_interval):
+    def __init__(
+        self,
+        client_name,
+        hub_serial,
+        hub_host,
+        mqtt_port,
+        mqtt_user,
+        mqtt_password,
+        hub_user,
+        hub_password,
+        scan_interval,
+    ):
         """Initialize the sensor."""
         self.sensors = {}
         self.climates = {}
@@ -228,7 +281,11 @@ class ComelitHub:
         self._vip = None
         self._music = None
         self.client = mqtt.Client(client_id=client_name)
-        _LOGGER.info("{0} {1}:{2} {3}".format("Starting Comelit Hub integration", hub_host, mqtt_port, hub_serial))
+        _LOGGER.info(
+            "{0} {1}:{2} {3}".format(
+                "Starting Comelit Hub integration", hub_host, mqtt_port, hub_serial
+            )
+        )
         self.topic_rx = "{0}/{1}/{2}/{3}".format("HSrv", hub_serial, "rx", client_name)
         self.topic_tx = "{0}/{1}/{2}/{3}".format("HSrv", hub_serial, "tx", client_name)
         self.client.hub = self
@@ -241,7 +298,7 @@ class ComelitHub:
         self.status_thread = StatusUpdater("Thread#1", self._scan_interval, self)
 
     def start(self):
-        
+
         self.client.loop_start()
         self.status_thread.start()
 
@@ -264,10 +321,15 @@ class ComelitHub:
             _LOGGER.error(e)
 
     def manage_announce(self, payload):
-        self.agent_id = payload['out_data'][0]["agent_id"]
+        self.agent_id = payload["out_data"][0]["agent_id"]
         _LOGGER.debug("Announce. Agent id is %s", self.agent_id)
-        req = {"req_type": RequestType.LOGIN, "req_sub_type": -1, "agent_type": 0, "user_name": self.hub_user,
-               "password": self.hub_password}
+        req = {
+            "req_type": RequestType.LOGIN,
+            "req_sub_type": -1,
+            "agent_type": 0,
+            "user_name": self.hub_user,
+            "password": self.hub_password,
+        }
         self.publish(req)
 
     def token(self, payload):
@@ -298,21 +360,30 @@ class ComelitHub:
         self.publish(req)
 
     def publish(self, data):
-        publish(self.client, self.topic_rx, self.agent_id, self.sequence_id, self.sessiontoken, data)
+        publish(
+            self.client,
+            self.topic_rx,
+            self.agent_id,
+            self.sequence_id,
+            self.sessiontoken,
+            data,
+        )
         self.sequence_id = self.sequence_id + 1
 
     def update_sensor(self, id, description, data):
         try:
             if HubClasses.POWER_CONSUMPTION in id or HubClasses.FTV in id:
-                value = format(float(data[HubFields.INSTANT_POWER]), '.2f')
+                value = format(float(data[HubFields.INSTANT_POWER]), ".2f")
                 prod = data[HubFields.PRODUCTION] == "1"
                 sensor = PowerSensor(id, description, value, prod)
             else:
-                value = format(float(data[HubFields.TEMPERATURE]), '.1f')
+                value = format(float(data[HubFields.TEMPERATURE]), ".1f")
                 value = float(value) / 10
                 sensor = TemperatureSensor(id, description, value)
 
-                if data["type"] == 9 and data["sub_type"] == 16:# Add the humidity sensor
+                if (
+                    data["type"] == 9 and data["sub_type"] == 16
+                ):  # Add the humidity sensor
                     humidity = data[HubFields.HUMIDITY]
                     humidity_sensor = HumiditySensor(id, description, humidity)
                     self.add_or_update_sensor(humidity_sensor, humidity)
@@ -324,7 +395,7 @@ class ComelitHub:
     def add_or_update_sensor(self, sensor, value):
         name = sensor.entity_name
         if sensor.name not in self.sensors:  # Add the new sensor
-            if hasattr(self, 'sensor_add_entities'):
+            if hasattr(self, "sensor_add_entities"):
                 self.sensor_add_entities([sensor])
                 self.sensors[name] = sensor
                 _LOGGER.info("added the sensor %s", name)
@@ -336,30 +407,32 @@ class ComelitHub:
         try:
             assert HubClasses.TEMPERATURE in id
             # _LOGGER.debug("update_climate: %s has data %s", description, data)
-            measured_temp = format(float(data[HubFields.TEMPERATURE]), '.1f')
+            measured_temp = format(float(data[HubFields.TEMPERATURE]), ".1f")
             measured_temp = float(measured_temp) / 10
 
-            target = format(float(data[HubFields.TARGET_TEMPERATURE]), '.1f')
+            target = format(float(data[HubFields.TARGET_TEMPERATURE]), ".1f")
             target = float(target) / 10
 
-            is_enabled = int(data['auto_man']) == 2
+            is_enabled = int(data["auto_man"]) == 2
             is_winter_season = bool(int(data[HubFields.WINTER_SEASON]))
             status = bool(int(data[HubFields.STATUS]))
-            state_dict = {'is_enabled': is_enabled,
-            'is_winter_season': is_winter_season,
-            'status': status,
-            'measured_temperature': measured_temp,
-            'target_temperature': target}
+            state_dict = {
+                "is_enabled": is_enabled,
+                "is_winter_season": is_winter_season,
+                "status": status,
+                "measured_temperature": measured_temp,
+                "target_temperature": target,
+            }
 
             # support sensors without humidity
             if HubFields.HUMIDITY in data:
-                state_dict['measured_humidity'] = float(data[HubFields.HUMIDITY])
+                state_dict["measured_humidity"] = float(data[HubFields.HUMIDITY])
 
             climate = ComelitClimate(id, description, state_dict, CommandHub(self))
 
             name = climate.entity_name
             if climate.name not in self.climates:  # Add the new sensor
-                if hasattr(self, 'climate_add_entities'):
+                if hasattr(self, "climate_add_entities"):
                     self.climate_add_entities([climate])
                     self.climates[name] = climate
                     _LOGGER.info("added the climate %s", name)
@@ -372,55 +445,71 @@ class ComelitHub:
     def update_light(self, id, description, data):
         try:
             # _LOGGER.debug("update_light: %s has data %s", description, data)
-            
+
             # Dimmable light (3=light, 4=dimmable)
             if data["type"] == 3 and data["sub_type"] == 4:
                 brightness = int(data["bright"])
+                rgb = None
+            elif data["type"] == 3 and data["sub_type"] == 2:
+                brightness = int(data["bright"])
+                rgb = tuple(int(x) for x in data["rgb_value"])
             else:
                 brightness = None
+                rgb = None
 
-            if data["status"] == "1":
-                state = STATE_ON
-            else:
+            if data["status"] == "0":
                 state = STATE_OFF
+            else:
+                state = STATE_ON
 
-            light = ComelitLight(id, description, state, brightness, CommandHub(self))
+            light = ComelitLight(
+                id, description, state, brightness, rgb, CommandHub(self)
+            )
             if id not in self.lights:  # Add the new sensor
-                if hasattr(self, 'light_add_entities'):
+                if hasattr(self, "light_add_entities"):
                     self.light_add_entities([light])
                     self.lights[id] = light
-                    _LOGGER.info("added the light %s %s", description, light.entity_name)
+                    _LOGGER.info(
+                        "added the light %s %s", description, light.entity_name
+                    )
             else:
                 # _LOGGER.debug(f"updating the light {description} {light.entity_name} with state {state}")
-                self.lights[id].update_state(state)
+                self.lights[id].sync_with_hub(state, brightness, rgb)
         except Exception as e:
             _LOGGER.exception("Error updating light %s", e)
 
     def update_cover(self, id, description, data, status_key):
         try:
-            if 'position' in data:
-                if data['status'] == '0':
+            if "position" in data:
+                if data["status"] == "0":
                     # Not moving
-                    if data[status_key] == '1':
+                    if data[status_key] == "1":
                         state = STATE_OPEN
                     else:
                         state = STATE_CLOSED
-                elif data['status'] == '1':
+                elif data["status"] == "1":
                     state = STATE_OPENING
-                elif data['status'] == '2':
+                elif data["status"] == "2":
                     state = STATE_CLOSING
 
-                position = int(100 * float(data['position']) / 255)
+                position = int(100 * float(data["position"]) / 255)
             else:  # unable to define the position. works for legacy cover
                 state = STATE_UNKNOWN
                 position = -1
 
-            if id in self.covers: 
-                _LOGGER.debug("update_cover: updating the cover %s with state %s and position %f", id, state, position)
+            if id in self.covers:
+                _LOGGER.debug(
+                    "update_cover: updating the cover %s with state %s and position %f",
+                    id,
+                    state,
+                    position,
+                )
                 self.covers[id].update_state(state, position)
             else:  # Add the new cover
-                if hasattr(self, 'cover_add_entities'):
-                    cover = ComelitCover(id, description, state, position, CommandHub(self))
+                if hasattr(self, "cover_add_entities"):
+                    cover = ComelitCover(
+                        id, description, state, position, CommandHub(self)
+                    )
                     self.cover_add_entities([cover])
                     self.covers[id] = cover
                     _LOGGER.info("update_cover: added the cover %s %s", description, id)
@@ -432,7 +521,7 @@ class ComelitHub:
         try:
             scene = ComelitScenario(id, description, SceneHub(self))
             if id not in self.scenes:  # Add the new cover
-                if hasattr(self, 'scene_add_entities'):
+                if hasattr(self, "scene_add_entities"):
                     self.scene_add_entities([scene])
                     self.scenes[id] = scene
                     _LOGGER.info("added the scene %s %s", description, id)
@@ -442,13 +531,13 @@ class ComelitHub:
     def update_switch(self, id, description, data):
         try:
             switch = ComelitSwitch(id, description, None, CommandHub(self))
-            if data[HubFields.STATUS] == '1':
+            if data[HubFields.STATUS] == "1":
                 state = STATE_ON
             else:
                 state = STATE_OFF
 
             if id not in self.switches:  # Add the new cover
-                if hasattr(self, 'switch_add_entities'):
+                if hasattr(self, "switch_add_entities"):
                     self.switch_add_entities([switch])
                     self.switches[id] = switch
                     _LOGGER.info("added the switch %s %s", description, id)
@@ -478,14 +567,19 @@ class ComelitHub:
                 except Exception:
                     pass
 
-                if HubClasses.POWER_CONSUMPTION in entity_id or HubClasses.FTV in entity_id:
+                if (
+                    HubClasses.POWER_CONSUMPTION in entity_id
+                    or HubClasses.FTV in entity_id
+                ):
                     description = item[HubFields.DESCRIPTION]
                     self.update_sensor(entity_id, description, item)
                 elif HubClasses.TEMPERATURE in entity_id:
                     description = item[HubFields.DESCRIPTION]
                     self.update_sensor(entity_id, description, item)
                     # skip creating the climate sensor for the PT100 sensor and add compatibility for ONE
-                    if HubFields.SUB_TYPE in item and (item["sub_type"] == 16 or item["sub_type"] == 12):# skip creating the climate sensor for the PT100 sensor
+                    if HubFields.SUB_TYPE in item and (
+                        item["sub_type"] == 16 or item["sub_type"] == 12
+                    ):  # skip creating the climate sensor for the PT100 sensor
                         self.update_climate(entity_id, description, item)
                 elif HubClasses.LIGHT in entity_id:
                     description = item[HubFields.DESCRIPTION]
@@ -493,7 +587,9 @@ class ComelitHub:
                 elif HubClasses.COVER in entity_id:
                     description = item[HubFields.DESCRIPTION]
                     _LOGGER.debug("processing cover %s: %s", description, item)
-                    self.update_cover(entity_id, description, item, HubFields.COVER_STATUS)
+                    self.update_cover(
+                        entity_id, description, item, HubFields.COVER_STATUS
+                    )
                 elif HubClasses.AUTOMATION in entity_id:
                     description = item[HubFields.DESCRIPTION]
                     self.update_cover(entity_id, description, item, HubFields.STATUS)
@@ -522,7 +618,12 @@ class ComelitHub:
 def update_status(hub):
     try:
         _LOGGER.debug("Publishing the status request")
-        req = {"req_type": RequestType.STATUS, "req_sub_type": -1, "obj_id": "GEN#17#13#1", "detail_level": 1}
+        req = {
+            "req_type": RequestType.STATUS,
+            "req_sub_type": -1,
+            "obj_id": "GEN#17#13#1",
+            "detail_level": 1,
+        }
         hub.publish(req)
     except Exception as e:
         _LOGGER.error("Error updating status")
@@ -530,7 +631,7 @@ def update_status(hub):
 
 
 # Make a request for status
-class StatusUpdater (Thread):
+class StatusUpdater(Thread):
     def __init__(self, name, scan_interval, hub):
         Thread.__init__(self)
         self.name = name
@@ -545,4 +646,3 @@ class StatusUpdater (Thread):
 
             update_status(self.hub)
             time.sleep(self._scan_interval)
-

--- a/custom_components/comelit/light.py
+++ b/custom_components/comelit/light.py
@@ -1,29 +1,34 @@
 """Platform for light integration."""
+
 import logging
 
 # Import the device class from the component that you want to support
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, LightEntity, ColorMode)
-from homeassistant.const import STATE_ON, STATE_OFF
+    ATTR_BRIGHTNESS,
+    ATTR_RGB_COLOR,
+    ColorMode,
+    LightEntity,
+)
+from homeassistant.const import STATE_OFF, STATE_ON
 
-from .const import DOMAIN
 from .comelit_device import ComelitDevice
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
-    hass.data[DOMAIN]['hub'].light_add_entities = add_entities
+    hass.data[DOMAIN]["hub"].light_add_entities = add_entities
     _LOGGER.info("Comelit Light Integration started")
 
 
 class ComelitLight(ComelitDevice, LightEntity):
-
-    def __init__(self, id, description, state, brightness, light_hub):
+    def __init__(self, id, description, state, brightness, rgb, light_hub):
         ComelitDevice.__init__(self, id, None, description)
         self._light = light_hub
         self._state = state
         self._brightness = brightness
+        self._rgb = rgb
 
     @property
     def is_on(self):
@@ -32,12 +37,20 @@ class ComelitLight(ComelitDevice, LightEntity):
 
     @property
     def supported_color_modes(self):
-        return {ColorMode.BRIGHTNESS} if self._brightness is not None else {ColorMode.ONOFF}
+        if self._rgb is not None:
+            return {ColorMode.RGB}
+        return (
+            {ColorMode.BRIGHTNESS}
+            if self._brightness is not None
+            else {ColorMode.ONOFF}
+        )
 
     @property
     def color_mode(self):
+        if self._rgb is not None:
+            return ColorMode.RGB
         return ColorMode.BRIGHTNESS if self._brightness is not None else ColorMode.ONOFF
-    
+
     @property
     def brightness(self):
         return self._brightness
@@ -45,14 +58,30 @@ class ComelitLight(ComelitDevice, LightEntity):
     def update(self):
         pass
 
+    @property
+    def rgb_color(self):
+        return self._rgb
+
+    def sync_with_hub(self, state, brightness, rgb):
+        """Update the light from a hub status poll (hub is the source of truth)."""
+        self._brightness = brightness
+        self._rgb = rgb
+        self.update_state(state)
+
     def turn_on(self, **kwargs):
         if ATTR_BRIGHTNESS in kwargs:
             self._brightness = kwargs[ATTR_BRIGHTNESS]
-        self._light.light_on(self._id, self._brightness)
-        self._state = STATE_ON # Immediately update the state, don't wait for the next update
+        if ATTR_RGB_COLOR in kwargs:
+            self._rgb = kwargs[ATTR_RGB_COLOR]
+        self._light.light_on(self._id, self._brightness, self._rgb)
+        self._state = (
+            STATE_ON  # Immediately update the state, don't wait for the next update
+        )
         self.schedule_update_ha_state()
-        
+
     def turn_off(self, **kwargs):
         self._light.light_off(self._id)
-        self._state = STATE_OFF # Immediately update the state, don't wait for the next update
+        self._state = (
+            STATE_OFF  # Immediately update the state, don't wait for the next update
+        )
         self.schedule_update_ha_state()

--- a/custom_components/comelit/vedo.py
+++ b/custom_components/comelit/vedo.py
@@ -130,9 +130,11 @@ class ComelitVedo:
         for i in range(1, ARM_DISARM_ATTEMPT+1):
             try:
                 uid = self.login()
-                path = "{0}?vedo=1&{1}={2}&force=1".format(VedoRequest.ACTION, key, id)
-                self.get(uid, path, False)
-                _LOGGER.info("Armed/Disarmed the area %s", id)
+                headers = DEFAULT_HEADERS.copy()
+                url, headers = self.build_http(headers, uid, VedoRequest.ACTION)
+                params = {"forced": 1,"vedo_param": 1, "type_param": key , "area_param": id}
+                self.post(url, params, headers)
+                _LOGGER.info("Armed/Disarmed the area: %s", id)
                 self.logout(uid)
                 break
             except Exception as e:

--- a/custom_components/comelit/vedo.py
+++ b/custom_components/comelit/vedo.py
@@ -191,12 +191,19 @@ class ComelitVedo:
         try:
             area_id = area["id"]
             name = area["name"]
-            if area["armed"] == 4:
-                state = AlarmControlPanelState.ARMED_AWAY
-            elif area["armed"] == 1:
-                state = AlarmControlPanelState.ARMED_NIGHT
+            if area["armed"] > 0:
+              if area['out_time'] == 1:
+                   state = AlarmControlPanelState.ARMING
+              elif area["alarm"] == 1 or area["sabotage"] == 1 or area["anomaly"] == 1:
+                   state = AlarmControlPanelState.TRIGGERED
+              elif area["armed"] == 4:
+                   state = AlarmControlPanelState.ARMED_AWAY
+              elif area["armed"] == 1:
+                   state = AlarmControlPanelState.ARMED_NIGHT
             else:
                 state = AlarmControlPanelState.DISARMED
+            
+
 
             if area_id not in self.areas:
                 if hasattr(self, 'alarm_add_entities'):

--- a/custom_components/comelit/vedo.py
+++ b/custom_components/comelit/vedo.py
@@ -63,10 +63,13 @@ class ComelitVedo:
             headers['Cookie'] = uid
 
         millis = int(round(time.time() * 1000))
-        if "?" in path:
-            url = "http://{0}:{1}/{2}&_={3}".format(self.host, self.port, path, millis)
+        if ".cgi" in path:
+            url = "http://{0}:{1}/{2}".format(self.host, self.port, path)
         else:
-            url = "http://{0}:{1}/{2}?_={3}".format(self.host, self.port, path, millis)
+            if "?" in path:
+                url = "http://{0}:{1}/{2}&_={3}".format(self.host, self.port, path, millis)
+            else:
+                url = "http://{0}:{1}/{2}?_={3}".format(self.host, self.port, path, millis)
         return url, headers
 
     # Do the GET from the vedo IP

--- a/custom_components/comelit/vedo.py
+++ b/custom_components/comelit/vedo.py
@@ -250,6 +250,7 @@ class SensorUpdater (Thread):
                 in_area = zone_desc["in_area"]
                 descs = areas_desc["description"]
                 ready = areas_stat["ready"]
+                present = areas_desc["present"] 
 
                 sensors = []
 
@@ -283,19 +284,20 @@ class SensorUpdater (Thread):
                     out_time = areas_stat["out_time"]
 
                     for i in range(len(descs)):
-                        area = {"name": descs[i],
-                                "id": i,
-                                "p1_pres": p1_pres[i],
-                                "p2_pres": p2_pres[i],
-                                "ready": ready[i],
-                                "armed": armed[i],
-                                "alarm": alarm[i],
-                                "alarm_memory": alarm_memory[i],
-                                "sabotage": sabotage[i],
-                                "anomaly": anomaly[i],
-                                "in_time": in_time[i],
-                                "out_time": out_time[i]}
-                        self._vedo.update_area(area)
+                        if present[i] == 1:
+                            area = {"name": descs[i],
+                                    "id": i,
+                                    "p1_pres": p1_pres[i],
+                                    "p2_pres": p2_pres[i],
+                                    "ready": ready[i],
+                                    "armed": armed[i],
+                                    "alarm": alarm[i],
+                                    "alarm_memory": alarm_memory[i],
+                                    "sabotage": sabotage[i],
+                                    "anomaly": anomaly[i],
+                                    "in_time": in_time[i],
+                                    "out_time": out_time[i]}
+                            self._vedo.update_area(area)
             except CookieException:
                 self.logout()
             except Exception as e:

--- a/tests/hub_status_rgb_off.json
+++ b/tests/hub_status_rgb_off.json
@@ -1,0 +1,254 @@
+{
+  "req_type": 0,
+  "req_sub_type": -1,
+  "seq_id": 1,
+  "req_result": 0,
+  "out_data": [
+    {
+      "id": "GEN#17#13#1",
+      "type": 1001,
+      "sub_type": 13,
+      "descrizione": "root",
+      "sched_status": "0",
+      "status": "0",
+      "powerst": "0",
+      "schedZoneStatus": [
+        0,
+        0,
+        0
+      ],
+      "elements": [
+        {
+          "id": "GEN#PL#388",
+          "data": {
+            "id": "GEN#PL#388",
+            "type": 1001,
+            "sub_type": 13,
+            "descrizione": "Luci P1",
+            "sched_status": "0",
+            "status": "0",
+            "powerst": "0",
+            "schedZoneStatus": [
+              0,
+              0,
+              0
+            ],
+            "placeOrder": "0",
+            "elements": [
+              {
+                "id": "DOM#LT#32.1",
+                "data": {
+                  "id": "DOM#LT#32.1",
+                  "type": 3,
+                  "sub_type": 4,
+                  "descrizione": "Corridoio",
+                  "sched_status": "0",
+                  "status": "0",
+                  "powerst": "0",
+                  "num_modulo": "32",
+                  "num_uscita": "1",
+                  "zero_dimmer": "3",
+                  "presenza": "0",
+                  "icon_id": "0",
+                  "isProtected": "0",
+                  "objectId": "DOM#LT#32.1",
+                  "placeId": "GEN#PL#388",
+                  "value": "255",
+                  "bright": "255",
+                  "presenza_on": "0",
+                  "presente": "0",
+                  "auto_man_pid_dimmer": "0"
+                }
+              },
+              {
+                "id": "DOM#LT#40.1",
+                "data": {
+                  "id": "DOM#LT#40.1",
+                  "type": 3,
+                  "sub_type": 2,
+                  "descrizione": "Camera RGB",
+                  "sched_status": "0",
+                  "status": "0",
+                  "powerst": "0",
+                  "num_modulo": "40",
+                  "num_uscita": "1",
+                  "icon_id": "0",
+                  "isProtected": "0",
+                  "objectId": "DOM#LT#40.1",
+                  "placeId": "GEN#PL#388",
+                  "rgb_value": [
+                    "248",
+                    "252",
+                    "128"
+                  ],
+                  "rgb_value_raw": [
+                    "248",
+                    "252",
+                    "128"
+                  ],
+                  "rgb_value_888": [
+                    "255",
+                    "255",
+                    "131"
+                  ],
+                  "bright": "255"
+                }
+              },
+              {
+                "id": "DOM#LT#33.1",
+                "data": {
+                  "id": "DOM#LT#33.1",
+                  "type": 3,
+                  "sub_type": 4,
+                  "descrizione": "Bagno",
+                  "sched_status": "0",
+                  "status": "0",
+                  "powerst": "0",
+                  "num_modulo": "33",
+                  "num_uscita": "1",
+                  "zero_dimmer": "3",
+                  "presenza": "0",
+                  "icon_id": "0",
+                  "isProtected": "0",
+                  "objectId": "DOM#LT#33.1",
+                  "placeId": "GEN#PL#388",
+                  "value": "201",
+                  "bright": "201",
+                  "presenza_on": "0",
+                  "presente": "0",
+                  "auto_man_pid_dimmer": "0"
+                }
+              },
+              {
+                "id": "DOM#LT#10.1",
+                "data": {
+                  "id": "DOM#LT#10.1",
+                  "type": 3,
+                  "sub_type": 1,
+                  "descrizione": "Lavanderia",
+                  "sched_status": "0",
+                  "status": "0",
+                  "powerst": "0",
+                  "num_modulo": 10,
+                  "num_uscita": 1,
+                  "ConsumptionThreshold": -1,
+                  "isShiomMis": 0,
+                  "instant_power": 0,
+                  "totalConsumption": -1,
+                  "isDetached": 0,
+                  "icon_id": "0",
+                  "isProtected": "0",
+                  "objectId": "DOM#LT#10.1",
+                  "placeId": "GEN#PL#388"
+                }
+              },
+              {
+                "id": "DOM#LT#10.2",
+                "data": {
+                  "id": "DOM#LT#10.2",
+                  "type": 3,
+                  "sub_type": 1,
+                  "descrizione": "Camera Ospiti",
+                  "sched_status": "0",
+                  "status": "0",
+                  "powerst": "0",
+                  "num_modulo": 10,
+                  "num_uscita": 2,
+                  "ConsumptionThreshold": -1,
+                  "isShiomMis": 0,
+                  "instant_power": 0,
+                  "totalConsumption": -1,
+                  "isDetached": 0,
+                  "icon_id": "0",
+                  "isProtected": "0",
+                  "objectId": "DOM#LT#10.2",
+                  "placeId": "GEN#PL#388"
+                }
+              },
+              {
+                "id": "DOM#LT#10.3",
+                "data": {
+                  "id": "DOM#LT#10.3",
+                  "type": 3,
+                  "sub_type": 1,
+                  "descrizione": "Studio",
+                  "sched_status": "0",
+                  "status": "0",
+                  "powerst": "0",
+                  "num_modulo": 10,
+                  "num_uscita": 3,
+                  "ConsumptionThreshold": -1,
+                  "isShiomMis": 0,
+                  "instant_power": 0,
+                  "totalConsumption": -1,
+                  "isDetached": 0,
+                  "icon_id": "0",
+                  "isProtected": "0",
+                  "objectId": "DOM#LT#10.3",
+                  "placeId": "GEN#PL#388"
+                }
+              },
+              {
+                "id": "DOM#LT#48.1",
+                "data": {
+                  "id": "DOM#LT#48.1",
+                  "type": 3,
+                  "sub_type": 2,
+                  "descrizione": "Bagno RGB",
+                  "sched_status": "0",
+                  "status": "0",
+                  "powerst": "0",
+                  "num_modulo": "48",
+                  "num_uscita": "1",
+                  "icon_id": "0",
+                  "isProtected": "0",
+                  "objectId": "DOM#LT#48.1",
+                  "placeId": "GEN#PL#388",
+                  "rgb_value": [
+                    "16",
+                    "66",
+                    "248"
+                  ],
+                  "rgb_value_raw": [
+                    "7",
+                    "31",
+                    "119"
+                  ],
+                  "rgb_value_888": [
+                    "8",
+                    "32",
+                    "123"
+                  ],
+                  "bright": "123"
+                }
+              },
+              {
+                "id": "DOM#LT#10.8",
+                "data": {
+                  "id": "DOM#LT#10.8",
+                  "type": 3,
+                  "sub_type": 1,
+                  "descrizione": "Ventola Lavanderia",
+                  "sched_status": "0",
+                  "status": "0",
+                  "powerst": "0",
+                  "num_modulo": 10,
+                  "num_uscita": 8,
+                  "ConsumptionThreshold": -1,
+                  "isShiomMis": 0,
+                  "instant_power": 0,
+                  "totalConsumption": -1,
+                  "isDetached": 0,
+                  "icon_id": "0",
+                  "isProtected": "0",
+                  "objectId": "DOM#LT#10.8",
+                  "placeId": "GEN#PL#388"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/hub_status_rgb_on.json
+++ b/tests/hub_status_rgb_on.json
@@ -1,0 +1,254 @@
+{
+  "req_type": 0,
+  "req_sub_type": -1,
+  "seq_id": 1,
+  "req_result": 0,
+  "out_data": [
+    {
+      "id": "GEN#17#13#1",
+      "type": 1001,
+      "sub_type": 13,
+      "descrizione": "root",
+      "sched_status": "0",
+      "status": "0",
+      "powerst": "0",
+      "schedZoneStatus": [
+        0,
+        0,
+        0
+      ],
+      "elements": [
+        {
+          "id": "GEN#PL#388",
+          "data": {
+            "id": "GEN#PL#388",
+            "type": 1001,
+            "sub_type": 13,
+            "descrizione": "Luci P1",
+            "sched_status": "0",
+            "status": "0",
+            "powerst": "0",
+            "schedZoneStatus": [
+              0,
+              0,
+              0
+            ],
+            "placeOrder": "0",
+            "elements": [
+              {
+                "id": "DOM#LT#32.1",
+                "data": {
+                  "id": "DOM#LT#32.1",
+                  "type": 3,
+                  "sub_type": 4,
+                  "descrizione": "Corridoio",
+                  "sched_status": "0",
+                  "status": "0",
+                  "powerst": "0",
+                  "num_modulo": "32",
+                  "num_uscita": "1",
+                  "zero_dimmer": "3",
+                  "presenza": "0",
+                  "icon_id": "0",
+                  "isProtected": "0",
+                  "objectId": "DOM#LT#32.1",
+                  "placeId": "GEN#PL#388",
+                  "value": "255",
+                  "bright": "255",
+                  "presenza_on": "0",
+                  "presente": "0",
+                  "auto_man_pid_dimmer": "0"
+                }
+              },
+              {
+                "id": "DOM#LT#40.1",
+                "data": {
+                  "id": "DOM#LT#40.1",
+                  "type": 3,
+                  "sub_type": 2,
+                  "descrizione": "Camera RGB",
+                  "sched_status": "0",
+                  "status": "0",
+                  "powerst": "0",
+                  "num_modulo": "40",
+                  "num_uscita": "1",
+                  "icon_id": "0",
+                  "isProtected": "0",
+                  "objectId": "DOM#LT#40.1",
+                  "placeId": "GEN#PL#388",
+                  "rgb_value": [
+                    "248",
+                    "252",
+                    "128"
+                  ],
+                  "rgb_value_raw": [
+                    "248",
+                    "252",
+                    "128"
+                  ],
+                  "rgb_value_888": [
+                    "255",
+                    "255",
+                    "131"
+                  ],
+                  "bright": "255"
+                }
+              },
+              {
+                "id": "DOM#LT#33.1",
+                "data": {
+                  "id": "DOM#LT#33.1",
+                  "type": 3,
+                  "sub_type": 4,
+                  "descrizione": "Bagno",
+                  "sched_status": "0",
+                  "status": "0",
+                  "powerst": "0",
+                  "num_modulo": "33",
+                  "num_uscita": "1",
+                  "zero_dimmer": "3",
+                  "presenza": "0",
+                  "icon_id": "0",
+                  "isProtected": "0",
+                  "objectId": "DOM#LT#33.1",
+                  "placeId": "GEN#PL#388",
+                  "value": "201",
+                  "bright": "201",
+                  "presenza_on": "0",
+                  "presente": "0",
+                  "auto_man_pid_dimmer": "0"
+                }
+              },
+              {
+                "id": "DOM#LT#10.1",
+                "data": {
+                  "id": "DOM#LT#10.1",
+                  "type": 3,
+                  "sub_type": 1,
+                  "descrizione": "Lavanderia",
+                  "sched_status": "0",
+                  "status": "0",
+                  "powerst": "0",
+                  "num_modulo": 10,
+                  "num_uscita": 1,
+                  "ConsumptionThreshold": -1,
+                  "isShiomMis": 0,
+                  "instant_power": 0,
+                  "totalConsumption": -1,
+                  "isDetached": 0,
+                  "icon_id": "0",
+                  "isProtected": "0",
+                  "objectId": "DOM#LT#10.1",
+                  "placeId": "GEN#PL#388"
+                }
+              },
+              {
+                "id": "DOM#LT#10.2",
+                "data": {
+                  "id": "DOM#LT#10.2",
+                  "type": 3,
+                  "sub_type": 1,
+                  "descrizione": "Camera Ospiti",
+                  "sched_status": "0",
+                  "status": "0",
+                  "powerst": "0",
+                  "num_modulo": 10,
+                  "num_uscita": 2,
+                  "ConsumptionThreshold": -1,
+                  "isShiomMis": 0,
+                  "instant_power": 0,
+                  "totalConsumption": -1,
+                  "isDetached": 0,
+                  "icon_id": "0",
+                  "isProtected": "0",
+                  "objectId": "DOM#LT#10.2",
+                  "placeId": "GEN#PL#388"
+                }
+              },
+              {
+                "id": "DOM#LT#10.3",
+                "data": {
+                  "id": "DOM#LT#10.3",
+                  "type": 3,
+                  "sub_type": 1,
+                  "descrizione": "Studio",
+                  "sched_status": "0",
+                  "status": "0",
+                  "powerst": "0",
+                  "num_modulo": 10,
+                  "num_uscita": 3,
+                  "ConsumptionThreshold": -1,
+                  "isShiomMis": 0,
+                  "instant_power": 0,
+                  "totalConsumption": -1,
+                  "isDetached": 0,
+                  "icon_id": "0",
+                  "isProtected": "0",
+                  "objectId": "DOM#LT#10.3",
+                  "placeId": "GEN#PL#388"
+                }
+              },
+              {
+                "id": "DOM#LT#48.1",
+                "data": {
+                  "id": "DOM#LT#48.1",
+                  "type": 3,
+                  "sub_type": 2,
+                  "descrizione": "Bagno RGB",
+                  "sched_status": "0",
+                  "status": "7",
+                  "powerst": "7",
+                  "num_modulo": "48",
+                  "num_uscita": "1",
+                  "icon_id": "0",
+                  "isProtected": "0",
+                  "objectId": "DOM#LT#48.1",
+                  "placeId": "GEN#PL#388",
+                  "rgb_value": [
+                    "16",
+                    "66",
+                    "248"
+                  ],
+                  "rgb_value_raw": [
+                    "7",
+                    "31",
+                    "119"
+                  ],
+                  "rgb_value_888": [
+                    "8",
+                    "32",
+                    "123"
+                  ],
+                  "bright": "123"
+                }
+              },
+              {
+                "id": "DOM#LT#10.8",
+                "data": {
+                  "id": "DOM#LT#10.8",
+                  "type": 3,
+                  "sub_type": 1,
+                  "descrizione": "Ventola Lavanderia",
+                  "sched_status": "0",
+                  "status": "0",
+                  "powerst": "0",
+                  "num_modulo": 10,
+                  "num_uscita": 8,
+                  "ConsumptionThreshold": -1,
+                  "isShiomMis": 0,
+                  "instant_power": 0,
+                  "totalConsumption": -1,
+                  "isDetached": 0,
+                  "icon_id": "0",
+                  "isProtected": "0",
+                  "objectId": "DOM#LT#10.8",
+                  "placeId": "GEN#PL#388"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -10,7 +10,7 @@ from custom_components.comelit.light import ComelitLight
 @pytest.fixture
 def comelit_light():
     light_hub = Mock()
-    light = ComelitLight("id", "description", STATE_ON, 255, light_hub)
+    light = ComelitLight("id", "description", STATE_ON, 255, None, light_hub)
     light.schedule_update_ha_state = lambda *args, **kwargs: None
     return light
 

--- a/tests/test_light_rgb.py
+++ b/tests/test_light_rgb.py
@@ -1,0 +1,128 @@
+"""RGB light tests.
+
+The fixtures (hub_status_rgb_on/off.json) are real captures from a
+production SimpleHome hub (serial 002529174B6A). Note the protocol
+quirk they document: an ON RGB light reports ``status: "7"`` (not
+``"1"`` like on/off lights), and the hub retains ``bright``/
+``rgb_value`` even while the light is off.
+
+Historical bug: ``ComelitLight.color_mode`` returned the *set*
+``{ColorMode.RGB}`` for RGB lights instead of the single
+``ColorMode.RGB`` enum. HA core evaluates ``color_mode.value`` while
+computing state attributes, so every state write for an RGB light
+raised ``AttributeError`` and the entity was stuck at its initial
+(off) state while the physical light happily turned on.
+"""
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+from homeassistant.components.light import ColorMode
+from homeassistant.const import STATE_OFF, STATE_ON
+
+from custom_components.comelit.hub import ComelitHub
+from custom_components.comelit.light import ComelitLight
+
+RGB_ID = "DOM#LT#48.1"  # "Bagno RGB", a real light on the captured hub
+
+
+def load_fixture(name):
+    filename = os.path.join(os.path.dirname(__file__), name)
+    with open(filename, "r") as json_file:
+        return json.load(json_file)
+
+
+def make_hub():
+    with patch("paho.mqtt.client.Client"):
+        hub = ComelitHub(
+            client_name="test",
+            hub_serial="00000000",
+            hub_host="127.0.0.1",
+            hub_user="user",
+            hub_password="pwd",
+            mqtt_port=1883,
+            mqtt_user="user",
+            mqtt_password="pwd",
+            scan_interval=30,
+        )
+    for name in ("sensor", "light", "cover", "climate", "scene", "switch"):
+        setattr(hub, f"{name}_add_entities", lambda *args, **kwargs: None)
+    return hub
+
+
+# --- light entity: color_mode must be a single ColorMode -----------------
+
+
+def test_rgb_light_color_mode():
+    light = ComelitLight(RGB_ID, "Bagno RGB", STATE_OFF, 123, (16, 66, 248), MagicMock())
+
+    # must be a single enum value, not a set: HA core does `color_mode.value`
+    assert isinstance(light.color_mode, ColorMode)
+    assert light.color_mode == ColorMode.RGB
+    assert light.color_mode.value == "rgb"
+    assert light.color_mode in light.supported_color_modes
+    assert light.supported_color_modes == {ColorMode.RGB}
+    assert light.rgb_color == (16, 66, 248)
+    assert light.brightness == 123
+
+
+def test_onoff_light_color_mode():
+    light = ComelitLight("DOM#LT#10.1", "Lavanderia", STATE_OFF, None, None, MagicMock())
+    assert light.color_mode == ColorMode.ONOFF
+    assert light.color_mode.value == "onoff"
+    assert light.supported_color_modes == {ColorMode.ONOFF}
+
+
+def test_dimmable_light_color_mode():
+    light = ComelitLight("DOM#LT#34.1", "Cucina", STATE_OFF, 255, None, MagicMock())
+    assert light.color_mode == ColorMode.BRIGHTNESS
+    assert light.color_mode.value == "brightness"
+    assert light.supported_color_modes == {ColorMode.BRIGHTNESS}
+
+
+# --- hub status parsing for RGB lights ------------------------------------
+
+
+def test_hub_status_rgb_on():
+    hub = make_hub()
+    hub.status(load_fixture("hub_status_rgb_on.json"))
+
+    light = hub.lights.get(RGB_ID)
+    assert light is not None, "RGB light DOM#LT#48.1 should exist"
+    # an ON RGB light reports status "7" (not "1" as on/off lights do)
+    assert light._state == STATE_ON
+    assert light._rgb == (16, 66, 248)
+    assert light._brightness == 123
+
+
+def test_hub_status_rgb_off():
+    hub = make_hub()
+    hub.status(load_fixture("hub_status_rgb_off.json"))
+
+    light = hub.lights.get(RGB_ID)
+    assert light is not None, "RGB light DOM#LT#48.1 should exist"
+    assert light._state == STATE_OFF
+    # the hub retains the last color/brightness while the light is off
+    assert light._rgb == (16, 66, 248)
+    assert light._brightness == 123
+
+
+def test_hub_poll_keeps_rgb_light_in_sync():
+    """The entity state must follow the hub, poll after poll."""
+    hub = make_hub()
+
+    hub.status(load_fixture("hub_status_rgb_off.json"))
+    light = hub.lights.get(RGB_ID)
+    assert light is not None
+    assert light._state == STATE_OFF
+
+    # the light gets turned on (from HA or a wall switch)
+    hub.status(load_fixture("hub_status_rgb_on.json"))
+    assert light._state == STATE_ON
+    assert light._rgb == (16, 66, 248)
+    assert light._brightness == 123
+
+    # and back off again
+    hub.status(load_fixture("hub_status_rgb_off.json"))
+    assert light._state == STATE_OFF


### PR DESCRIPTION
Detect RGB lights (type 3, sub_type 2) in hub polls, parse rgb_value and sync state/brightness/rgb via sync_with_hub; turn_on sends the selected color (act_type 15). Adds real hub-status captures as test fixtures and unit tests.

There are some extra formatting changes (with ruff)